### PR TITLE
Support for de/re-serialization of the Device & DeviceState entities

### DIFF
--- a/device.go
+++ b/device.go
@@ -243,6 +243,47 @@ func (d Device) MarshalJSON() ([]byte, error) {
 	return json.Marshal(dr)
 }
 
+// UnmarshalJSON is a custom JSON deserializer for our Device
+func (d *Device) UnmarshalJSON(data []byte) error {
+	dr := deviceRaw{}
+	if err := json.Unmarshal(data, &dr); err != nil {
+		return err
+	}
+
+	if d.Traits == nil {
+		d.Traits = map[string]bool{}
+	}
+
+	d.ID = dr.ID
+	d.Type = dr.Type
+	for _, trait := range dr.Traits {
+		d.Traits[trait] = true
+	}
+	d.Name.DefaultNames = dr.Name.DefaultNames
+	d.Name.Name = dr.Name.Name
+	d.Name.Nicknames = dr.Name.Nicknames
+	d.WillReportState = dr.WillReportState
+	d.RoomHint = dr.RoomHint
+	d.attributes = dr.Attributes
+	d.DeviceInfo.Manufacturer = dr.DeviceInfo.Manufacturer
+	d.DeviceInfo.Model = dr.DeviceInfo.Model
+	d.DeviceInfo.HwVersion = dr.DeviceInfo.HwVersion
+	d.DeviceInfo.SwVersion = dr.DeviceInfo.SwVersion
+	for _, otherDeviceID := range dr.OtherDeviceIDs {
+		d.OtherDeviceIDs = append(d.OtherDeviceIDs, OtherDeviceID{
+			AgentID:  otherDeviceID.AgentID,
+			DeviceID: otherDeviceID.DeviceID,
+		})
+	}
+
+	d.CustomData = dr.CustomData
+	if d.CustomData == nil {
+		d.CustomData = map[string]interface{}{}
+	}
+
+	return nil
+}
+
 type otherDeviceIDraw struct {
 	AgentID  string `json:"agentId,omitempty"`
 	DeviceID string `json:"deviceId,omitempty"`

--- a/device_test.go
+++ b/device_test.go
@@ -1,0 +1,52 @@
+package action
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeviceJSONSerializeDeserialize(t *testing.T) {
+	origDevice := NewSimpleAVReceiver("test-id", []DeviceInput{
+		{
+			Key: "input-1",
+			Names: []DeviceInputName{
+				{
+					LanguageCode: "en-US",
+					Synonyms: []string{
+						"First Input",
+						"DVD Player",
+					},
+				},
+			},
+		},
+		{
+			Key: "input-2",
+			Names: []DeviceInputName{
+				{
+					LanguageCode: "en-US",
+					Synonyms: []string{
+						"Second Input",
+						"Computer",
+					},
+				},
+			},
+		},
+	}, 100, true, false)
+	origDevice.OtherDeviceIDs = append(origDevice.OtherDeviceIDs, OtherDeviceID{
+		AgentID:  "agent-id-test",
+		DeviceID: "test-id-other",
+	})
+
+	serializedBytes, serializeErr := json.Marshal(origDevice)
+	assert.Nil(t, serializeErr)
+
+	convDevice := Device{}
+	deserializeErr := json.Unmarshal(serializedBytes, &convDevice)
+	assert.Nil(t, deserializeErr)
+
+	reserializedBytes, reserializedErr := json.Marshal(convDevice)
+	assert.Nil(t, reserializedErr)
+	assert.Equal(t, serializedBytes, reserializedBytes)
+}

--- a/trait.go
+++ b/trait.go
@@ -99,3 +99,24 @@ func (ds DeviceState) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal(payload)
 }
+
+// UnmarshalJSON is a custom JSON deserializer for our DeviceState
+func (ds *DeviceState) UnmarshalJSON(data []byte) error {
+	payload := map[string]interface{}{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return err
+	}
+
+	if online, ok := payload["online"]; ok {
+		ds.Online = online.(bool)
+		delete(payload, "online")
+	}
+	if status, ok := payload["status"]; ok {
+		ds.Status = status.(string)
+		delete(payload, "status")
+	}
+
+	ds.state = payload
+
+	return nil
+}

--- a/trait_test.go
+++ b/trait_test.go
@@ -1,0 +1,27 @@
+package action
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeviceStateJSONSerializeDeserialize(t *testing.T) {
+	origState := NewDeviceState(true)
+	origState.RecordBrightness(50)
+	origState.RecordColorHSV(100, 100, 100)
+	origState.RecordOnOff(true)
+	origState.Status = "ONLINE"
+
+	serializedBytes, serializeErr := json.Marshal(origState)
+	assert.Nil(t, serializeErr)
+
+	convState := DeviceState{}
+	deserializeErr := json.Unmarshal(serializedBytes, &convState)
+	assert.Nil(t, deserializeErr)
+
+	reserializedBytes, reserializedErr := json.Marshal(convState)
+	assert.Nil(t, reserializedErr)
+	assert.Equal(t, serializedBytes, reserializedBytes)
+}


### PR DESCRIPTION
* this will allow for these types to be passed over the wire if needed
* type safety isn't completely handled due to arbitrary trait types
  - however, proper re-serialization is supported & tested for