### PR TITLE
Make 'state' & 'attributes' public to maximise genericity

### DIFF
--- a/device.go
+++ b/device.go
@@ -54,7 +54,7 @@ type Device struct {
 	RoomHint string
 
 	// Attributes linked to the defined traits
-	attributes map[string]interface{}
+	Attributes map[string]interface{}
 
 	// DeviceInfo that is physically defined
 	DeviceInfo DeviceInfo
@@ -72,7 +72,7 @@ func NewDevice(id string, typ string) *Device {
 		ID:         id,
 		Type:       typ,
 		Traits:     map[string]bool{},
-		attributes: map[string]interface{}{},
+		Attributes: map[string]interface{}{},
 		CustomData: map[string]interface{}{},
 	}
 }
@@ -127,7 +127,7 @@ func NewSwitch(id string) *Device {
 func (d *Device) AddBrightnessTrait(onlyCommand bool) *Device {
 	d.Traits["action.devices.traits.Brightness"] = true
 	if onlyCommand {
-		d.attributes["commandOnlyBrightness"] = true
+		d.Attributes["commandOnlyBrightness"] = true
 	}
 
 	return d
@@ -147,9 +147,9 @@ const (
 func (d *Device) AddColourTrait(model string, onlyCommand bool) *Device {
 	d.Traits["action.devices.traits.ColorSetting"] = true
 	if onlyCommand {
-		d.attributes["commandOnlyColorSetting"] = true
+		d.Attributes["commandOnlyColorSetting"] = true
 	}
-	d.attributes["colorModel"] = model
+	d.Attributes["colorModel"] = model
 
 	return d
 }
@@ -162,11 +162,11 @@ func (d *Device) AddColourTemperatureTrait(minTempK int, maxTempK int, onlyComma
 	d.Traits["action.devices.traits.ColorSetting"] = true
 
 	if onlyCommand {
-		d.attributes["commandOnlyColorSetting"] = true
+		d.Attributes["commandOnlyColorSetting"] = true
 	} else {
-		d.attributes["commandOnlyColorSetting"] = false
+		d.Attributes["commandOnlyColorSetting"] = false
 	}
-	d.attributes["colorTemperatureRange"] = map[string]int{
+	d.Attributes["colorTemperatureRange"] = map[string]int{
 		"temperatureMinK": minTempK,
 		"temperatureMaxK": maxTempK,
 	}
@@ -178,8 +178,8 @@ func (d *Device) AddColourTemperatureTrait(minTempK int, maxTempK int, onlyComma
 // See https://developers.google.com/assistant/smarthome/traits/inputselector
 func (d *Device) AddInputSelectorTrait(availableInputs []DeviceInput, ordered bool) *Device {
 	d.Traits["action.devices.traits.InputSelector"] = true
-	d.attributes["availableInputs"] = availableInputs
-	d.attributes["orderedInputs"] = ordered
+	d.Attributes["availableInputs"] = availableInputs
+	d.Attributes["orderedInputs"] = ordered
 
 	return d
 }
@@ -191,10 +191,10 @@ func (d *Device) AddInputSelectorTrait(availableInputs []DeviceInput, ordered bo
 func (d *Device) AddOnOffTrait(onlyCommand, onlyQuery bool) *Device {
 	d.Traits["action.devices.traits.OnOff"] = true
 	if onlyCommand {
-		d.attributes["commandOnlyOnOff"] = true
+		d.Attributes["commandOnlyOnOff"] = true
 	}
 	if onlyQuery {
-		d.attributes["queryOnlyOnOff"] = true
+		d.Attributes["queryOnlyOnOff"] = true
 	}
 
 	return d
@@ -205,10 +205,10 @@ func (d *Device) AddOnOffTrait(onlyCommand, onlyQuery bool) *Device {
 func (d *Device) AddVolumeTrait(maxLevel int, canMute bool, onlyCommand bool) *Device {
 	d.Traits["action.devices.traits.Volume"] = true
 	if onlyCommand {
-		d.attributes["commandOnlyVolume"] = true
+		d.Attributes["commandOnlyVolume"] = true
 	}
-	d.attributes["volumeMaxLevel"] = maxLevel
-	d.attributes["volumeCanMuteAndUnmute"] = canMute
+	d.Attributes["volumeMaxLevel"] = maxLevel
+	d.Attributes["volumeCanMuteAndUnmute"] = canMute
 
 	return d
 }
@@ -227,7 +227,7 @@ func (d Device) MarshalJSON() ([]byte, error) {
 	dr.Name.Nicknames = d.Name.Nicknames
 	dr.WillReportState = d.WillReportState
 	dr.RoomHint = d.RoomHint
-	dr.Attributes = d.attributes
+	dr.Attributes = d.Attributes
 	dr.DeviceInfo.Manufacturer = d.DeviceInfo.Manufacturer
 	dr.DeviceInfo.Model = d.DeviceInfo.Model
 	dr.DeviceInfo.HwVersion = d.DeviceInfo.HwVersion
@@ -264,7 +264,7 @@ func (d *Device) UnmarshalJSON(data []byte) error {
 	d.Name.Nicknames = dr.Name.Nicknames
 	d.WillReportState = dr.WillReportState
 	d.RoomHint = dr.RoomHint
-	d.attributes = dr.Attributes
+	d.Attributes = dr.Attributes
 	d.DeviceInfo.Manufacturer = dr.DeviceInfo.Manufacturer
 	d.DeviceInfo.Model = dr.DeviceInfo.Model
 	d.DeviceInfo.HwVersion = dr.DeviceInfo.HwVersion

--- a/handler.go
+++ b/handler.go
@@ -187,7 +187,7 @@ func (s *Service) GoogleFulfillmentHandler(w http.ResponseWriter, r *http.Reques
 		if len(pExecuteResp.UpdatedDevices) > 0 {
 			commandSuccessResp := executeRespPayload{
 				Status: "SUCCESS",
-				States: pExecuteResp.UpdatedState.state,
+				States: pExecuteResp.UpdatedState.State,
 			}
 			commandSuccessResp.States["online"] = true
 			for _, id := range pExecuteResp.UpdatedDevices {

--- a/trait.go
+++ b/trait.go
@@ -7,14 +7,14 @@ type DeviceState struct {
 	Online bool
 	Status string
 
-	state map[string]interface{}
+	State map[string]interface{}
 }
 
 // NewDeviceState creates a new device state to be added to as defined by the relevant traits on a device.
 func NewDeviceState(online bool) DeviceState {
 	return DeviceState{
 		Online: online,
-		state:  map[string]interface{}{},
+		State:  map[string]interface{}{},
 	}
 }
 
@@ -22,7 +22,7 @@ func NewDeviceState(online bool) DeviceState {
 // Should only be applied to devices with the Brightness trait
 // See https://developers.google.com/assistant/smarthome/traits/brightness
 func (ds DeviceState) RecordBrightness(brightness int) DeviceState {
-	ds.state["brightness"] = brightness
+	ds.State["brightness"] = brightness
 	return ds
 }
 
@@ -30,7 +30,7 @@ func (ds DeviceState) RecordBrightness(brightness int) DeviceState {
 // Should only be applied to devices with the ColorSetting trait
 // See https://developers.google.com/assistant/smarthome/traits/colorsetting
 func (ds DeviceState) RecordColorTemperature(temperatureK int) DeviceState {
-	ds.state["color"] = map[string]interface{}{
+	ds.State["color"] = map[string]interface{}{
 		"temperatureK": temperatureK,
 	}
 	return ds
@@ -40,7 +40,7 @@ func (ds DeviceState) RecordColorTemperature(temperatureK int) DeviceState {
 // Should only be applied to devices with the ColorSetting trait
 // See https://developers.google.com/assistant/smarthome/traits/colorsetting
 func (ds DeviceState) RecordColorRGB(spectrumRgb int) DeviceState {
-	ds.state["color"] = map[string]interface{}{
+	ds.State["color"] = map[string]interface{}{
 		"spectrumRgb": spectrumRgb,
 	}
 	return ds
@@ -50,7 +50,7 @@ func (ds DeviceState) RecordColorRGB(spectrumRgb int) DeviceState {
 // Should only be applied to devices with the ColorSetting trait
 // See https://developers.google.com/assistant/smarthome/traits/colorsetting
 func (ds DeviceState) RecordColorHSV(hue float64, saturation float64, value float64) DeviceState {
-	ds.state["color"] = map[string]interface{}{
+	ds.State["color"] = map[string]interface{}{
 		"spectrumHsv": map[string]interface{}{
 			"hue":        hue,
 			"saturation": saturation,
@@ -64,7 +64,7 @@ func (ds DeviceState) RecordColorHSV(hue float64, saturation float64, value floa
 // Should only be applied to devices with the InputSelector trait
 // See https://developers.google.com/assistant/smarthome/traits/inputselector
 func (ds DeviceState) RecordInput(input string) DeviceState {
-	ds.state["input"] = input
+	ds.State["input"] = input
 	return ds
 }
 
@@ -72,7 +72,7 @@ func (ds DeviceState) RecordInput(input string) DeviceState {
 // Should only be applied to devices with the OnOff trait
 // See https://developers.google.com/assistant/smarthome/traits/onoff
 func (ds DeviceState) RecordOnOff(on bool) DeviceState {
-	ds.state["on"] = on
+	ds.State["on"] = on
 	return ds
 }
 
@@ -80,8 +80,8 @@ func (ds DeviceState) RecordOnOff(on bool) DeviceState {
 // Should only be applied to devices with the Volume trait
 // See https://developers.google.com/assistant/smarthome/traits/volume
 func (ds DeviceState) RecordVolume(volume int, isMuted bool) DeviceState {
-	ds.state["currentVolume"] = volume
-	ds.state["isMuted"] = isMuted
+	ds.State["currentVolume"] = volume
+	ds.State["isMuted"] = isMuted
 	return ds
 }
 
@@ -93,7 +93,7 @@ func (ds DeviceState) MarshalJSON() ([]byte, error) {
 		payload["status"] = ds.Status
 	}
 
-	for k, v := range ds.state {
+	for k, v := range ds.State {
 		payload[k] = v
 	}
 
@@ -116,7 +116,7 @@ func (ds *DeviceState) UnmarshalJSON(data []byte) error {
 		delete(payload, "status")
 	}
 
-	ds.state = payload
+	ds.State = payload
 
 	return nil
 }


### PR DESCRIPTION
It makes little sense to have these fields private as the library does not cover all [traits and device types](https://developers.google.com/assistant/smarthome/traits).

Fix issue #6.