### PR TITLE
Add github action to enforce go build and go test works.

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,0 +1,19 @@
+name: Go build and test
+run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
+on: [push]
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "The name of the branch is ${{ github.ref }}, and the repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
+      - name: go build
+        run: go build
+      - name: go test
+        run: go test
+      - name: go test -count 10 (check determinism)
+        run: go test -count 20


### PR DESCRIPTION
See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-status-checks-before-merging for how to protect the main branch using the presubmit action.

Github actions is free for public projects, so this shouldn't cost anything to enable.